### PR TITLE
Virtual files were created in the wrong places

### DIFF
--- a/lib/orangejuice.js
+++ b/lib/orangejuice.js
@@ -82,8 +82,8 @@ OJ.prototype.createFileStream = function(sourceFile) {
 
       }else if(typeof pattern === 'string' && pattern == 'self') {
         var fileStream = utils.createFromStream(new File({
-          base: _this.sourcePath,
-          path: path.join(_this.sourcePath, sourceFile.name),
+          base: path.dirname(sourceFile.path),
+          path: sourceFile.path,
           contents: new Buffer(sourceFile.body)
         }));
 
@@ -119,8 +119,8 @@ OJ.prototype.createFileStream = function(sourceFile) {
     // until the getChunk function is called.
     // Spaghetti code! Refactor soon..
     stream = utils.createFromStream(new File({
-      base: _this.sourcePath,
-      path: path.join(_this.sourcePath, sourceFile.name),
+      base: path.dirname(sourceFile.path),
+      path: sourceFile.path,
       contents: new Buffer(sourceFile.body)
     }));
   }


### PR DESCRIPTION
- All files were put in the build root dir instead of their respective folder
- base was incompatible with other gulp plugins (e,g, gulp-less) in a way that they were unable to use relative file resources
