### PR TITLE
plugins need to be able to hook in later in the process!

### DIFF
--- a/lib/orangejuice.js
+++ b/lib/orangejuice.js
@@ -36,9 +36,20 @@ var OJ = function(mode, rootPath) {
 
   this.preProcessors = defaultProcessors.pre;
   this.postProcessors = defaultProcessors.post;
+
+  // store callbacks for when run() is called the first time
+  this.firstRunCallbacks = [];
+
+  // expose logger to plugins
+  this.log = log;
 }
 
 OJ.IGNORE_PREFIX_PATTERN = new RegExp('\/_');
+
+// name?
+OJ.prototype.firstRun = function(func) {
+  this.firstRunCallbacks.push(func);
+}
 
 OJ.prototype.run = function(requestPaths, callback) {
   var _this = this;
@@ -96,6 +107,14 @@ OJ.prototype.run = function(requestPaths, callback) {
       callback( fileBufferSorted );
     });
   }
+
+  // run callbacks that plugins may have registered
+  // REVIEW: requestPaths.length == 0 tells us it's been run for the first time from boot.js... not sure if good solution
+  if (requestPaths.length == 0 && this.firstRunCallbacks.length > 0) {
+    for (var i = this.firstRunCallbacks.length; i--;) {
+      this.firstRunCallbacks[i](sourceFiles);
+    };
+  };
 
   // return allStreams;
 };


### PR DESCRIPTION
So right now, orangejuice-livereload gets the OJ object freshly instantiated,

```
var oj = require('orangejuice'),
    livereload = require('orangejuice-livereload'),
    html2js = require('gulp-html2js');

livereload(oj);
...
```

which means it only get's the default values of things. User-specified things in ojfile hasn't yet been saved in the oj singleton etc.

The oj-livereload module would need to be initialized later to get the correct values from OJ. It looks like the earliest point it can be run would be on the first next tick:

```
// boot.js

process.nextTick(function(){
  // like here.. !
  OJ.run();
});
```

So I did a callback test which is triggered in the `OJ.run()` method the first time it's run, because I wanted to get ahold of the `sourceFiles` array and give it to livereload :)

It seems to work fine, but I don't know how and where it makes sense to put a callback like this in OJ really, I suppose it depends a lot on possible future plugins. In this specific case I needed to hook in after ojfile.js has been evaluated once, but I also needed to steal the sourceFiles array :) 

Anyway, drop some comments on what you think would be best! Also if this functionality is even necessary, a user could probably just set the required settings for oj-livereload in ojfile as well.

And this is a [PR that shows how this looks from the orangejuice-livereload perspective](https://github.com/javoire/orangejuice-livereload/pull/6/files)
