### PR TITLE
Added unix shebang to the lingon.js examples that that they'll work 'out...

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,14 @@ Create a "lingon.js" file in the root of the project and make it executable:
 This file is used to both configure and run Lingon. This is where you define which plugins to use and how they should interact. The most basic valid "lingon.js" file looks like this:
 
 ```JavaScript
+#!/usr/bin/env node
 var lingon = require("lingon");
 ```
 
 This will allow Lingon to build and serve a basic web applications. By default, Lingon will look for source files in `./source` and put build files in `./build`. These defaults can be changed like this: 
 
 ```JavaScript
+#!/usr/bin/env node
 var lingon = require("lingon");
 
 lingon.sourcePath = "/some/other/path";


### PR DESCRIPTION
... of the box'.

Change-Id: If6df302b9b6d89289d0bf31801263155beb73ca8

Currently, when running through the example, if you just type "./lingon.js" you'll get an error as the shell can't guess what to run the file with.

A shebang solves it! (yay)
