### PR TITLE
Bumping dependency versions to stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "test": "./test.sh"
   },
   "dependencies": {
-    "express": "~4.9.0",
-    "send": "~0.9.1",
+    "express": "~4.10.2",
+    "send": "~0.10.1",
     "chalk": "~0.5.1",
     "event-stream": "3.1.7",
     "gulp-concat": "~2.4.0",
@@ -46,18 +46,18 @@
     "shellwords": "~0.1.0",
     "through": "~2.3.4",
     "from": "~0.1.3",
-    "gulp-ejs": "~0.3.1",
+    "gulp-ejs": "~1.0.0",
     "gulp-less": "~1.3.5",
     "vinyl-fs": "~0.3.7",
     "vinyl": "~0.4.3",
     "rimraf": "~2.2.6",
-    "minimatch": "~0.2.14",
+    "minimatch": "~1.0.0",
     "resumer": "~0.0.0",
     "gulp-markdown": "~1.0.0",
     "ordered-merge-stream": "~0.0.0",
     "q": "~2.0.0",
-    "lex": "1.7.6",
-    "tape": "~2.14.0"
+    "lex": "1.7.7",
+    "tape": "~3.0.3"
   },
   "devDependencies": {
     "lingon-ng-html2js": "~0.1.6"


### PR DESCRIPTION
I have tested this with test.sh. 40 tests succeeded and 0 failed.

This should make the david-dm dependency status green, and also remove the annoying deprecation warning message from the express library.
