### PR TITLE
Add log warning about concatenating/including third-party .less files

### DIFF
--- a/lib/defaults/defaultProcessors.js
+++ b/lib/defaults/defaultProcessors.js
@@ -1,8 +1,10 @@
+var chalk         = require('chalk');
 var ejs           = require('gulp-ejs');
 var less          = require('gulp-less');
 var markdown      = require('gulp-markdown');
 var es            = require('event-stream');
 var streamHelper  = require('../utils/stream');
+var log           = require('../utils/log');
 
 module.exports = {
   pre: {
@@ -43,7 +45,17 @@ module.exports = {
       {
         filePattern: null,
         pipe: function() {
-          return less();
+          lessInstance = less();
+
+          lessInstance.on('error', function(err){
+            if(err.message.indexOf("' wasn't found") > -1) {
+              log(
+                chalk.yellow('The error below usually implies that you´ve used "//= include" on a third-party .less file. Use @import instead.')
+              );
+            }
+          });
+
+          return lessInstance;
         }
       }
     ]


### PR DESCRIPTION
This is an addition to the error message that I first considered a bug in the issue https://github.com/spotify/lingon/issues/108

As the //= include statement will only concatenate the files, one should use less import statements for third-party .less files instead of the lingon include.

The warning text that will be added will just tell the user of lingon that the import error is due to using the lingon include statement instead of the less import.
