### PR TITLE
add an info and error function to the logger

### DIFF
--- a/lib/boot.js
+++ b/lib/boot.js
@@ -18,7 +18,7 @@ var rootPath = process.cwd();
 // Display version?
 if(!!argv.v || tasks[0] === 'version') {
   var pkg = require('../package.json');
-  log('Lingon version:', pkg.version);
+  log.info('Lingon version:', pkg.version);
   process.exit();
 }
 
@@ -49,7 +49,7 @@ process.nextTick(function() {
   // if no tasks have been supplied use the default one
   tasks = tasks.length > 0 ? tasks : [lingon.config.defaultTask];
 
-  log('Working directory:', chalk.magenta(rootPath));
+  log.info('Working directory:', chalk.magenta(rootPath));
   lingon.run(tasks);
 });
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -13,7 +13,7 @@ var Builder = {};
 
 Builder.createPipeline = function(sourceFile) {
   var transforms = Array.prototype.slice.call(arguments, 1);
-  
+
   for(var i=0;i<transforms.length;i++) {
     sourceFile = transforms[i].call(this, sourceFile);
   }
@@ -67,18 +67,18 @@ Builder.rewriteExtension = function(params) {
     var extensionMap = params.extensionMap;
     var sourceFilename = path.basename(sourceFile.path);
 
-    // Only apply the rewrite to registered processors 
-    // (to allow the default extensions to be passed through if desired, 
+    // Only apply the rewrite to registered processors
+    // (to allow the default extensions to be passed through if desired,
     // for instance to output a index.coffee file.)
 
     var registeredExtensionMap = utils.getRegisteredExtensions(
-      sourceFilename, 
-      extensionMap, 
+      sourceFilename,
+      extensionMap,
       processorStores
     );
 
     var targetFilename = ExtensionRewriter.transform({
-      filename: sourceFilename, 
+      filename: sourceFilename,
       extensionMap: registeredExtensionMap
     });
 
@@ -99,7 +99,7 @@ Builder.rewriteExtension = function(params) {
 };
 
 Builder.print = function(sourceFile) {
-  log(chalk.green(sourceFile.path, "->", path.join(sourceFile.targetPath, sourceFile.targetFilename)));
+  log.info(chalk.green(sourceFile.path, "->", path.join(sourceFile.targetPath, sourceFile.targetFilename)));
   return sourceFile;
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -141,12 +141,12 @@ var server = function(lingon, ip, port) {
   process.on('uncaughtException', function(error) {
     if(error.code == 'EADDRINUSE') {
       console.error('[ ' + chalk.red('Lingon') + ' ] ' + chalk.yellow('[Error] Port ' + port + ' is already in use, lingon server could not start!'));
-      log('[Info] Try with a different one: ' + chalk.blue( 'lingon server -p <PORT>'));
+      log.info('[Info] Try with a different one: ' + chalk.blue( 'lingon server -p <PORT>'));
     }
   });
 
   app.listen(port, ip, function() {
-    log('http server listening on: http://' + ip + ':' + port);
+    log.info('http server listening on: http://' + ip + ':' + port);
     lingon.trigger('serverStarted');
   });
 

--- a/lib/streams/directiveStream.js
+++ b/lib/streams/directiveStream.js
@@ -70,7 +70,7 @@ module.exports = function directiveStream(env, context, node) {
       var patterns = parsedFile.patterns;
 
       if(cyclicDependencyDetected(node, sourceFile.path)) {
-        log('[Warning] File is trying to include itself (ignored): "' + path.relative(env.rootPath, sourceFile.path +'"'));
+        log.info('[Warning] File is trying to include itself (ignored): "' + path.relative(env.rootPath, sourceFile.path +'"'));
 
         if(sourceFile.path.indexOf(".js" > -1)) {
           var output = '//[lingon] ERROR: Cyclic dependency in "' + path.relative(env.rootPath, sourceFile.path) + '"';
@@ -127,7 +127,7 @@ module.exports = function directiveStream(env, context, node) {
               contents: new Buffer(pattern.args.contents)
             }));
 
-            // Pipe preProcessor streams 
+            // Pipe preProcessor streams
             // (applied to every included file before concatenation)
             fileStream = preProcess(fileStream);
 

--- a/lib/tasks/clean.js
+++ b/lib/tasks/clean.js
@@ -5,7 +5,7 @@ module.exports = function(lingon) {
   lingon.registerTask('clean', function(callback) {
     rimraf(path.join(lingon.rootPath, lingon.config.buildPath), function(error) {
       if (!error) {
-        lingon.log('[Info] The ' + lingon.config.buildPath + ' folder has been cleaned');
+        lingon.log.info('[Info] The ' + lingon.config.buildPath + ' folder has been cleaned');
       } else {
         console.error('[ ' + chalk.red('Lingon') + ' ] ' + chalk.yellow('[Error] The ' + lingon.config.buildPath + ' folder could not be cleaned'));
       }

--- a/lib/utils/extensionRewriter.js
+++ b/lib/utils/extensionRewriter.js
@@ -45,7 +45,7 @@ ExtensionRewriter.transform = function(args) {
   var segments = [];
 
   // Instantiate a lexer
-  // Pass in a default function that will add all 
+  // Pass in a default function that will add all
   // unmatched chars to the segments array.
   var lexer = new Lexer(function (char) {
     segments.push(char);
@@ -79,7 +79,7 @@ ExtensionRewriter.transform = function(args) {
 
   // Return the basename + new extensions in order, or empty basename.
   return segments.join('');
-  
+
 };
 
 ExtensionRewriter.reverseTransform = function(args) {
@@ -117,7 +117,7 @@ ExtensionRewriter.reverseTransform = function(args) {
     }else{
       return ["." + segment];
     }
-    
+
   });
 
   function allCombinations(arr) {

--- a/lib/utils/help.js
+++ b/lib/utils/help.js
@@ -23,7 +23,7 @@ module.exports = {
     descriptions[task] = description || {message: ''};
   },
   show: function(cmd, task) {
-    log('Usage:');
+    log.info('Usage:');
     console.log('');
 
     if(!task) {

--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -1,7 +1,19 @@
 var chalk = require('chalk');
 
-module.exports = function() {
+function Logger() {
+
+}
+
+Logger.prototype.info = function() {
   console.log.apply(null, ['[ ' + chalk.red('Lingon') + ' ]'].concat(
     Array.prototype.slice.call(arguments, 0)
   ));
 };
+
+Logger.prototype.error = function() {
+  console.log.apply(null, ['[ ' + chalk.red('Lingon') + ' ]'].concat(
+    chalk.yellow('[Error] ' + Array.prototype.slice.call(arguments, 0))
+  ));
+};
+
+module.exports = new Logger();


### PR DESCRIPTION
Also useful in plugins: 
```js
// lingon-livereload
    process.on('uncaughtException', function(error) {
      if(error.code == 'EADDRINUSE') {
        lingon.log.error('Port ' + config.port + ' is already in use, lingon-livereload could not start!');
        lingon.log.info('[Info] Try changing the port in your lingon-livereload config');
        process.exit();
      }
    });
```