### PR TITLE
Better error message for port conflict on server start (fixes #118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD
+
+* Fix: Output a clearer error message if a port conflict occurs during server startup
+
 ## Version 2.2.0
 
 * Feature: Add option to pass in complete file path to conditional processor's regexp instead of just the file name

--- a/lib/server.js
+++ b/lib/server.js
@@ -140,8 +140,8 @@ var server = function(lingon, ip, port) {
 
   process.on('uncaughtException', function(error) {
     if(error.code == 'EADDRINUSE') {
-      log.error('Port ' + port + ' is already in use, lingon server could not start!');
-      log.info('[Info] Try with a different one: ' + chalk.blue( 'lingon server -p <PORT>'));
+      log.error('A port is already in use, lingon could not start properly!');
+      log.info('[Info] Try starting lingon with a different port (' + chalk.blue( 'lingon server -p <PORT>') + ') or check your plugin configurations.');
     }
   });
 


### PR DESCRIPTION
Will output like this:

```sh
[ Lingon ] [Error] A port is already in use, lingon could not start properly!
[ Lingon ] [Info] Try starting lingon with a different port (lingon server -p <PORT>) or check your plugin configurations.
```