### PR TITLE
Fix readme badges being blurry

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ![Image of Lingon berries]
 (https://farm3.staticflickr.com/2548/3873990304_1d2bd40ebc_m.jpg)<br>
 
-[![Build Status](https://travis-ci.org/spotify/lingon.png?branch=master)](https://travis-ci.org/spotify/lingon)
-[![Dependency Status](https://david-dm.org/spotify/lingon.png)](https://david-dm.org/spotify/lingon)
+[![Build Status](https://travis-ci.org/spotify/lingon.svg?branch=master)](https://travis-ci.org/spotify/lingon)
+[![Dependency Status](https://david-dm.org/spotify/lingon.svg)](https://david-dm.org/spotify/lingon)
 
 Lingon is a performant single-page application dev tool that focuses on developer happiness.<br />
 At Spotify we use Lingon to build Angular.js applications.


### PR DESCRIPTION
Changes to use the SVG versions of the badges in the readme.

<img width="537" alt="diff" src="https://cloud.githubusercontent.com/assets/23453/12243229/56333cfc-b86b-11e5-8f01-44671439bc57.png">
