### PR TITLE
Disable use of sudo in CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
 - '0.10'
 - '0.12'


### PR DESCRIPTION
This will also [migrate the jobs](https://docs.travis-ci.com/user/migrating-from-legacy/) from Travis-CI’s legacy infrastructure to the new container based infrastructure. Which should make builds start sooner, run faster and have access to more resources (CPU, RAM, network, …).

More info can also be found in their blog post “[Moving To A More Elastic Future: Upcoming Build Infrastructure Migration](https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future)”.

:tada: 

@philipvonbargen @javoire 