### PR TITLE
Bugfix: Keep the longest command length to make sure lingon help works

### DIFF
--- a/lib/utils/help.js
+++ b/lib/utils/help.js
@@ -21,7 +21,8 @@ function printArgument(arg, message) {
 
 module.exports = {
   describe: function (task, description) {
-    maxPartition = minPartition + task.length;
+    var newPartitionSize = minPartition + task.length;
+    maxPartition = Math.max(maxPartition, newPartitionSize);
     descriptions[task] = description || { message: '' };
   },
 


### PR DESCRIPTION
The command `lingon help` started crashing when I added a new command with a longer name than the current ones (static-server). This was because the max length was not stored, instead the last command parsed decided the total length.

This fixes that bug :cake: 

@philipvonbargen 