### PR TITLE
pass hostname and port on serverConfigure event

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -11,6 +11,9 @@ var server = function (lingon, ip, port, requestHandler) {
 
   lingon.server = app;
 
+  // chrome started disallowing 0.0.0.0 in the browser URL
+  var hostname = ip == '0.0.0.0' ? 'localhost' : ip;
+
   var catchAllHandler = function (request, response, next) {
     if (!response.body && lingon.config.server.catchAll) {
       lingon.build({
@@ -33,7 +36,7 @@ var server = function (lingon, ip, port, requestHandler) {
 
   app.use(lingon.config.server.namespace, requestHandler);
 
-  lingon.trigger('serverConfigure');
+  lingon.trigger('serverConfigure', hostname, port);
   app.use(catchAllHandler);
   app.use(responseHandler);
 
@@ -51,7 +54,6 @@ var server = function (lingon, ip, port, requestHandler) {
   });
 
   app.listen(port, ip, function () {
-    var hostname = ip == '0.0.0.0' ? 'localhost' : ip; // chrome started disallowing 0.0.0.0 in the browser URL
     log.info('http server listening on: http://' + hostname + ':' + port +
         lingon.config.server.namespace);
     lingon.trigger('serverStarted');


### PR DESCRIPTION
I have a use case where I need to tell an express middleware what hostname and port the server is running on (it can't figure that out on its own..):

```js
lingon.one('serverConfigure', function(hostname, port) {

  prism.create({
    name: 'api',
    context: '/api',
    mode: proxyMode,
    mocksPath: 'test/mocks',
    host: hostname,
    port: port,
    mockFilenameGenerator: 'humanReadable',
    //delay: 'fast',
    rewrite: {
      '^/api': '/real/api'
    }
  });
  lingon.server.use(prism.middleware);
```