### PR TITLE
Better exception handling

### DIFF
--- a/lib/boot.js
+++ b/lib/boot.js
@@ -34,6 +34,12 @@ var lingon = new Lingon(rootPath, argv);
 // This allows the lingonfile to be evaluated in it's entirety
 // before we run.
 
+// Catch any exception and make sure lingon exits with a non zero exit code
+process.on('uncaughtException', function (err) {
+  log.error(err);
+  process.exit(2);
+});
+
 process.nextTick(function () {
 
   // Display help?

--- a/lib/utils/stream.js
+++ b/lib/utils/stream.js
@@ -58,6 +58,9 @@ module.exports = {
       streamErrors.push(new Error('[Stream Error] ' + message));
       stream.destroy();
       stream.emit('end');
+
+      throw(error);
+
     };
 
     for (var i = 0; i < pipes.length; i++) {

--- a/tests/system/stream-error2/lingon.js
+++ b/tests/system/stream-error2/lingon.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var lingon = require('../../../lib/boot');

--- a/tests/system/stream-error2/source/all.js
+++ b/tests/system/stream-error2/source/all.js
@@ -1,0 +1,1 @@
+//= include 'asd asd a '

--- a/tests/system/stream-error2/stream-error2.bats
+++ b/tests/system/stream-error2/stream-error2.bats
@@ -1,0 +1,15 @@
+# Test Lingon against the simplest project possible.
+# Covers: Building, Concatenating, Serving over http
+
+# Before each spec
+setup() {
+  CWD='tests/system/stream-error2'
+  cd $CWD
+}
+
+@test "stream-error2: exits with code 2 on uncaughtException" {
+  # Build project
+  run ./lingon.js build > /dev/null 2> /dev/null
+
+  [ $status -eq 2 ]
+}


### PR DESCRIPTION
I noticed that lingon doesn't always exit with an appropriate error code on failure. Some stream exceptions were not caught by the existing error handling, which meant lingon would exit with status `0`. This has been tripping up our build pipelines.

I added global exception handling in the boot script and changed the stream helper to always re-throw exceptions to surface them in case the existing error handling logic misses them. 

This is a bit of a hack... a real solution would be to completely overhaul the stream exception handling, but I'm not sure it's a good idea to invest in that. 

This fix will at least guarantee that lingon exits with status `2` on all uncaught exceptions. As an added bonus, the error messages look much nicer. 

From:
![old_error](https://cloud.githubusercontent.com/assets/347361/19530718/4b4aca00-9635-11e6-9b32-ba4bb48c8220.png)

To:
![new_error](https://cloud.githubusercontent.com/assets/347361/19530726/52872bf6-9635-11e6-84a9-ceb1950a6eba.png)

@javoire @philipvonbargen 
